### PR TITLE
自動マイグレーションと自動タイムスタンプ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1.25.0
 
 WORKDIR /app
 
@@ -22,4 +22,4 @@ EXPOSE 8080
 
 ENV PATH="/usr/local/go/bin:$(go env GOPATH)/bin:/root/go/bin:${PATH}"
 
-CMD ["air", "-c", ".air.toml"]
+CMD ["sh", "-c", "go run migrate/migrate.go && exec air -c .air.toml"]

--- a/model/user.go
+++ b/model/user.go
@@ -1,12 +1,15 @@
 package model
 
-import "todo-api/types"
+import (
+	"time"
+	"todo-api/types"
+)
 
 type User struct {
 	ID        types.UserID `json:"id" gorm:"primaryKey"`
 	Email     string       `json:"email" gorm:"unique"`
 	Password  string       `json:"password"`
-	CreatedAt int64        `json:"created_at" gorm:"autoUpdateTime"`
+	CreatedAt time.Time    `json:"created_at" gorm:"autoCreateTime"`
 }
 
 type UserResponse struct {


### PR DESCRIPTION
結局gormの設定をしなくても自動でタイムスタンプが設定された
int64だったらUNIX時間でDBに書き込まれるが，time.Timeだったら見慣れたフォーマットになる